### PR TITLE
Remove duplication of code after compiling

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -1,9 +1,5 @@
-@import "variables";
-@import "~bulma";
-
-@import "startpage";
 @import "header";
-@import "footer";
+@import "startpage";
 @import "components/daily_picks";
 @import "components/item_chart";
-@import "components/filter_panel";
+@import "footer";

--- a/resources/assets/sass/catalog.scss
+++ b/resources/assets/sass/catalog.scss
@@ -1,9 +1,4 @@
-@import "variables";
-@import "~bulma";
-
 @import "header";
-@import "footer";
-@import "components/filter_panel";
 
 .card-container {
     display: flex;
@@ -155,3 +150,5 @@
         flex-basis: 20%;
     }
   }
+  
+@import "footer";

--- a/resources/assets/sass/components/daily_picks.scss
+++ b/resources/assets/sass/components/daily_picks.scss
@@ -1,5 +1,3 @@
-@import "/../_variables";
-
 body {
 
   line-height: 1;

--- a/resources/assets/sass/components/filter_panel.scss
+++ b/resources/assets/sass/components/filter_panel.scss
@@ -1,6 +1,3 @@
-@import "/../_variables";
-@import "links";
-
 *,
 fieldset {
   border: none;

--- a/resources/assets/sass/components/item_chart.scss
+++ b/resources/assets/sass/components/item_chart.scss
@@ -1,5 +1,3 @@
-@import "/../_variables";
-
 main {
 
   .chart-section {

--- a/resources/assets/sass/components/item_meta_info.scss
+++ b/resources/assets/sass/components/item_meta_info.scss
@@ -1,6 +1,3 @@
-@import "/../_variables";
-@import "links";
-
 html {
   
   background-color: $background-color;

--- a/resources/assets/sass/components/links.scss
+++ b/resources/assets/sass/components/links.scss
@@ -1,4 +1,3 @@
-@import '../variables';
 @keyframes pulsate {
   
   0% {

--- a/resources/assets/sass/footer.scss
+++ b/resources/assets/sass/footer.scss
@@ -1,9 +1,3 @@
-// Fonts
-@import url("https://fonts.googleapis.com/css?family=Raleway:300,400,600");
-
-// Variables
-@import "_variables";
-
 html, body {
     background-color: #333333;
 }

--- a/resources/assets/sass/header.scss
+++ b/resources/assets/sass/header.scss
@@ -1,6 +1,6 @@
-@import "_variables";
-
-//hamburger
+@import "variables";
+@import "components/links";
+@import "~bulma";
 
 html,
 header, body {
@@ -21,7 +21,7 @@ main {
   display: flex;
   flex-direction: column;
   justify-content: center;
-  background-color: $background-color;
+  background-color: $background;
   color: white;
   margin-top: 25px;
 }

--- a/resources/assets/sass/input.scss
+++ b/resources/assets/sass/input.scss
@@ -1,5 +1,3 @@
-@import "variables";
-
 body {
 
   background-color:rgba(51, 51, 51, 0.74);

--- a/resources/assets/sass/register.scss
+++ b/resources/assets/sass/register.scss
@@ -1,12 +1,5 @@
-@import "variables";
-@import "~bulma";
-@import "header";
-
 main {
 
   margin-top: 175px;
   margin-bottom: 250px;
   }
-
-@import "footer";
-  

--- a/resources/assets/sass/startpage.scss
+++ b/resources/assets/sass/startpage.scss
@@ -1,5 +1,3 @@
-@import '_variables';
-
 main { 
 
   margin-bottom: 100px;

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -17,11 +17,3 @@ mix
   .js("resources/assets/js/filter_panel.js", "public/js")
   .sass("resources/assets/sass/app.scss", "public/css")
   .sass("resources/assets/sass/catalog.scss", "public/css")
-  .sass("resources/assets/sass/input.scss", "public/css")
-  .sass("resources/assets/sass/header.scss", "public/css")
-  .sass("resources/assets/sass/footer.scss", "public/css")
-  .sass("resources/assets/sass/register.scss", "public/css")
-  .sass("resources/assets/sass/components/item_meta_info.scss", "public/css")
-  .sass("resources/assets/sass/components/item_chart.scss", "public/css")
-  .sass("resources/assets/sass/components/daily_picks.scss", "public/css")
-  .sass("resources/assets/sass/components/filter_panel.scss", "public/css");


### PR DESCRIPTION
Previously, we made several superflous imports in the scss-files - which
results in duplicated code in the final css files (the files that is
linked in the head of each page).

Now _variables.scss is only imported in/by header.scss - since the
header will be imported in every site page.

Realising just now, maybe it would be a bit more effecient to abstract the head element to an independent blade-file, isolated from the header-blade.