### PR TITLE
Bugfix userlists ref issue 158

### DIFF
--- a/app/Http/Controllers/ListsController.php
+++ b/app/Http/Controllers/ListsController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Userlist;
+use App\UserList;
 use App\TitleList;
 use App\User;
 use App\Title;
@@ -77,7 +77,7 @@ class ListsController extends Controller
      * @param  \App\Userlist  $list
      * @return \Illuminate\Http\Response
      */
-    public function show(Userlist $list)
+    public function show(UserList $list)
     {
       
     }
@@ -88,7 +88,7 @@ class ListsController extends Controller
      * @param  \App\UserList  $list
      * @return \Illuminate\Http\Response
      */
-    public function edit(Userlist $list)
+    public function edit(UserList $list)
     {
         
     }
@@ -243,7 +243,7 @@ class ListsController extends Controller
      * @param  \App\UserList  $list
      * @return \Illuminate\Http\Response
      */
-    public function destroy(Userlist $list)
+    public function destroy(UserList $list)
     {
 
        try {


### PR DESCRIPTION
Found a incorrectly referenced class in the ListController, I was using App/Userlist instead of App/UserList
Localy this was not a problem but it is likely that it coused the lists not to function when deployed. Also I'm basing this assumption on the error received in the production environment when trying to add lists or add items to the list:  which is (in short) : 
(1/1) ReflectionException
Class App\Userlist does not exist

So I want to merge this code first to dev and then to prod do a new deploy to test if this solved the problem